### PR TITLE
Assume nightly Rust and remove `bench` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ hex = "^0.3"
 [features]
 yolocrypto = ["curve25519-dalek/yolocrypto"]
 std = ["curve25519-dalek/std"]
-bench = []

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ cargo test
 Run benchmarks:
 
 ```
-cargo bench --features="bench"
+cargo bench
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
-#![cfg_attr(feature = "bench", feature(test))]
+#![feature(test)]
 
 extern crate curve25519_dalek;
 extern crate sha2;
 extern crate rand;
 extern crate tiny_keccak;
 
-#[cfg(all(test, feature = "bench"))]
+#[cfg(test)]
 extern crate test;
 
 mod random_oracle;

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -343,7 +343,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "bench"))]
+#[cfg(test)]
 mod bench {
     use super::*;
     use rand::Rng;


### PR DESCRIPTION
This allows running `cargo bench` without extra flags as before by forcing the use of not-yet-stabilized `#![feature(test)]`.