### PR TITLE
Update to dalek v0.16.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Cathie <cathie@chain.com>"]
 
 [dependencies]
-curve25519-dalek = { version = "^0.15", features = ["nightly"] }
+curve25519-dalek = { version = "^0.16", features = ["nightly"] }
 sha2 = "^0.7"
 rand = "^0.4"
 byteorder = "1.2.1"
@@ -20,5 +20,3 @@ std = ["curve25519-dalek/std"]
 git = 'https://github.com/chain/tiny-keccak.git'
 rev = '5925f81b3c351440283c3328e2345d982aac0f6e'
 
-[patch.crates-io]
-curve25519-dalek = { git = 'https://github.com/dalek-cryptography/curve25519-dalek', branch = 'develop' }

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -23,7 +23,7 @@
 // XXX we should use Sha3 everywhere
 
 use curve25519_dalek::ristretto::RistrettoPoint;
-use sha2::{Digest, Sha256};
+use sha2::{Digest, Sha512};
 
 /// The `GeneratorsChain` creates an arbitrary-long sequence of orthogonal generators.
 /// The sequence can be deterministically produced starting with an arbitrary point.
@@ -34,7 +34,7 @@ struct GeneratorsChain {
 impl GeneratorsChain {
     /// Creates a chain of generators, determined by the hash of `label`.
     fn new(label: &[u8]) -> Self {
-        let mut hash = Sha256::default();
+        let mut hash = Sha512::default();
         hash.input(b"GeneratorsChainInit");
         hash.input(label);
         let next_point = RistrettoPoint::from_hash(hash);
@@ -52,7 +52,7 @@ impl Iterator for GeneratorsChain {
     type Item = RistrettoPoint;
     fn next(&mut self) -> Option<Self::Item> {
         let current_point = self.next_point;
-        let mut hash = Sha256::default();
+        let mut hash = Sha512::default();
         hash.input(b"GeneratorsChainNext");
         hash.input(current_point.compress().as_bytes());
         self.next_point = RistrettoPoint::from_hash(hash);
@@ -171,43 +171,6 @@ mod tests {
                 gens.all().H[2 * n..][..n].to_vec(),
             ],
             [gens.share(2).G[..].to_vec(), gens.share(2).H[..].to_vec()]
-        );
-    }
-
-    #[test]
-    fn generator_orthogonality() {
-        let n = 2;
-        let m = 1;
-        let gens = Generators::new(n, m);
-        let view = gens.all();
-
-        assert_eq!(
-            hex::encode(RISTRETTO_BASEPOINT_POINT.compress().as_bytes()),
-            "e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76"
-        );
-        assert_eq!(
-            hex::encode(view.B.compress().as_bytes()),
-            "6abd9de445ed16637be32da51bbd3fa114f984c52081258a1f476c8493f09731"
-        );
-        assert_eq!(
-            hex::encode(view.B_blinding.compress().as_bytes()),
-            "5c97d2b3cd6994ae1a4d6bd7371b40800b6a28afb1db14b81b4b5107ed9c5478"
-        );
-        assert_eq!(
-            hex::encode(view.G[0].compress().as_bytes()),
-            "688bac289f5e4ed902648278b4e81a2b8a028365b0a7753fd0242e499bd6200e"
-        );
-        assert_eq!(
-            hex::encode(view.G[1].compress().as_bytes()),
-            "7e49425c91464e4b3aa4c4676e7deba7e91d1cfd1a19a0a39dfd73b0cecdb55c"
-        );
-        assert_eq!(
-            hex::encode(view.H[0].compress().as_bytes()),
-            "50140daade760912586d04be961dab5d723d1aba05b536b13b99f69225ea4002"
-        );
-        assert_eq!(
-            hex::encode(view.H[1].compress().as_bytes()),
-            "ac23f3c0964e8bb1b9c61869edbb39c4417a96d518715d2e3e60a03cd722d13d"
         );
     }
 }

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -18,7 +18,7 @@ use generators::Generators;
 
 use range_proof::inner_product;
 
-use sha2::Sha256;
+use sha2::Sha512;
 
 #[derive(Clone, Debug)]
 pub struct Proof {
@@ -86,12 +86,12 @@ impl Proof {
             let c_L = inner_product(&a_L, &b_R);
             let c_R = inner_product(&a_R, &b_L);
 
-            let L = ristretto::vartime::multiscalar_mult(
+            let L = ristretto::vartime::multiscalar_mul(
                 a_L.iter().chain(b_R.iter()).chain(iter::once(&c_L)),
                 G_R.iter().chain(H_L.iter()).chain(iter::once(Q)),
             );
 
-            let R = ristretto::vartime::multiscalar_mult(
+            let R = ristretto::vartime::multiscalar_mul(
                 a_R.iter().chain(b_L.iter()).chain(iter::once(&c_R)),
                 G_L.iter().chain(H_R.iter()).chain(iter::once(Q)),
             );
@@ -108,8 +108,8 @@ impl Proof {
             for i in 0..n {
                 a_L[i] = a_L[i] * x + x_inv * a_R[i];
                 b_L[i] = b_L[i] * x_inv + x * b_R[i];
-                G_L[i] = ristretto::vartime::multiscalar_mult(&[x_inv, x], &[G_L[i], G_R[i]]);
-                H_L[i] = ristretto::vartime::multiscalar_mult(&[x, x_inv], &[H_L[i], H_R[i]]);
+                G_L[i] = ristretto::vartime::multiscalar_mul(&[x_inv, x], &[G_L[i], G_R[i]]);
+                H_L[i] = ristretto::vartime::multiscalar_mul(&[x, x_inv], &[H_L[i], H_R[i]]);
             }
 
             a = a_L;
@@ -203,7 +203,7 @@ impl Proof {
         let neg_x_sq = x_sq.iter().map(|xi| -xi);
         let neg_x_inv_sq = x_inv_sq.iter().map(|xi| -xi);
 
-        let expect_P = ristretto::vartime::multiscalar_mult(
+        let expect_P = ristretto::vartime::multiscalar_mul(
             iter::once(self.a * self.b)
                 .chain(a_times_s)
                 .chain(h_times_b_div_s)
@@ -238,7 +238,7 @@ mod tests {
         let H = gens.share(0).H.to_vec();
 
         // Q would be determined upstream in the protocol, so we pick a random one.
-        let Q = RistrettoPoint::hash_from_bytes::<Sha256>(b"test point");
+        let Q = RistrettoPoint::hash_from_bytes::<Sha512>(b"test point");
 
         // a and b are the vectors for which we want to prove c = <a,b>
         let a: Vec<_> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
@@ -257,7 +257,7 @@ mod tests {
         // a.iter() has Item=&Scalar, need Item=Scalar to chain with b_prime
         let a_prime = a.iter().cloned();
 
-        let P = ristretto::vartime::multiscalar_mult(
+        let P = ristretto::vartime::multiscalar_mul(
             a_prime.chain(b_prime).chain(iter::once(c)),
             G.iter().chain(H.iter()).chain(iter::once(&Q)),
         );
@@ -319,7 +319,7 @@ mod bench {
         let H = gens.share(0).H.to_vec();
 
         // Q would be determined upstream in the protocol, so we pick a random one.
-        let Q = RistrettoPoint::hash_from_bytes::<Sha256>(b"test point");
+        let Q = RistrettoPoint::hash_from_bytes::<Sha512>(b"test point");
 
         let a = vec![Scalar::from_u64(1); n];
         let b = vec![Scalar::from_u64(2); n];
@@ -346,7 +346,7 @@ mod bench {
         let H = gens.share(0).H.to_vec();
 
         // Q would be determined upstream in the protocol, so we pick a random one.
-        let Q = RistrettoPoint::hash_from_bytes::<Sha256>(b"test point");
+        let Q = RistrettoPoint::hash_from_bytes::<Sha512>(b"test point");
 
         let a = vec![Scalar::from_u64(1); n];
         let b = vec![Scalar::from_u64(2); n];
@@ -366,7 +366,7 @@ mod bench {
 
         let c = inner_product(&a, &b);
 
-        let P = ristretto::vartime::multiscalar_mult(
+        let P = ristretto::vartime::multiscalar_mul(
             a.iter().chain(b.iter()).chain(iter::once(&c)),
             G.iter().chain(H.iter()).chain(iter::once(&Q)),
         );

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -4,7 +4,7 @@ use rand::Rng;
 
 use std::iter;
 
-use sha2::{Digest, Sha256, Sha512};
+use sha2::{Digest, Sha512};
 
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::ristretto;
@@ -69,7 +69,7 @@ impl RangeProof {
         let H = generators.H.to_vec();
 
         let V =
-            ristretto::multiscalar_mult(&[Scalar::from_u64(v), *v_blinding], &[*B, *B_blinding]);
+            ristretto::multiscalar_mul(&[Scalar::from_u64(v), *v_blinding], &[*B, *B_blinding]);
 
         let a_blinding = Scalar::random(rng);
 
@@ -90,7 +90,7 @@ impl RangeProof {
         let s_R: Vec<_> = (0..n).map(|_| Scalar::random(rng)).collect();
 
         // Compute S = <s_L, G> + <s_R, H> + s_blinding * B_blinding.
-        let S = ristretto::multiscalar_mult(
+        let S = ristretto::multiscalar_mul(
             iter::once(&s_blinding).chain(s_L.iter()).chain(s_R.iter()),
             iter::once(B_blinding).chain(G.iter()).chain(H.iter()),
         );
@@ -128,8 +128,8 @@ impl RangeProof {
         // Form commitments T_1, T_2 to t.1, t.2
         let t_1_blinding = Scalar::random(rng);
         let t_2_blinding = Scalar::random(rng);
-        let T_1 = ristretto::multiscalar_mult(&[t_poly.1, t_1_blinding], &[*B, *B_blinding]);
-        let T_2 = ristretto::multiscalar_mult(&[t_poly.2, t_2_blinding], &[*B, *B_blinding]);
+        let T_1 = ristretto::multiscalar_mul(&[t_poly.1, t_1_blinding], &[*B, *B_blinding]);
+        let T_2 = ristretto::multiscalar_mul(&[t_poly.2, t_2_blinding], &[*B, *B_blinding]);
 
         // Commit to T_1, T_2 to get the challenge point x
         transcript.commit(T_1.compress().as_bytes());
@@ -218,7 +218,7 @@ impl RangeProof {
             .zip(util::exp_iter(y.invert()))
             .map(|((s_i_inv, exp_2), exp_y_inv)| z + exp_y_inv * (zz * exp_2 - b * s_i_inv));
 
-        let mega_check = ristretto::vartime::multiscalar_mult(
+        let mega_check = ristretto::vartime::multiscalar_mul(
             iter::once(Scalar::one())
                 .chain(iter::once(x))
                 .chain(iter::once(c * zz))


### PR DESCRIPTION
The hash-to-ristretto procedure now takes 64 bytes of randomness (it applies
Elligator twice), so the generators module is changed from Sha256 to Sha512.
The test with hardcoded vectors is removed, since all the points changed, and
checking that the points have specific hex encodings doesn't actually check
that they're orthogonal.