### PR TITLE
Remove experimental use of duplex Keccak and simply chain Sha512 calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ criterion = "0.2"
 yolocrypto = ["curve25519-dalek/yolocrypto"]
 std = ["curve25519-dalek/std"]
 
-[dependencies.tiny-keccak]
-git = 'https://github.com/chain/tiny-keccak.git'
-rev = '5925f81b3c351440283c3328e2345d982aac0f6e'
-
 [[bench]]
 name = "bulletproofs"
 harness = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ extern crate byteorder;
 extern crate curve25519_dalek;
 extern crate rand;
 extern crate sha2;
-extern crate tiny_keccak;
 
 #[cfg(test)]
 extern crate test;


### PR DESCRIPTION
This simplifies the ProofTranscript implementation by using a chain of SHA512 calls:

1. Experimental Keccak API fork with a bespoke half-duplex mode is not needed anymore.
2. No need for length prefixes for input messages. Each call uses one full sha512 permutation.
3. Challenges have now stricter separation. Squeeing 2+3 bytes in two calls is not the same as squeezing 5 bytes in one call.

Addresses #24 