### PR TITLE
Make prover constant time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,11 @@ curve25519-dalek = { version = "^0.16", features = ["nightly"] }
 sha2 = "^0.7"
 rand = "^0.4"
 byteorder = "1.2.1"
+subtle = "0.6"
+
+[dependencies.tiny-keccak]
+git = 'https://github.com/chain/tiny-keccak.git'
+rev = '5925f81b3c351440283c3328e2345d982aac0f6e'
 
 [dev-dependencies]
 hex = "^0.3"
@@ -16,10 +21,6 @@ criterion = "0.2"
 [features]
 yolocrypto = ["curve25519-dalek/yolocrypto"]
 std = ["curve25519-dalek/std"]
-
-[dependencies.tiny-keccak]
-git = 'https://github.com/chain/tiny-keccak.git'
-rev = '5925f81b3c351440283c3328e2345d982aac0f6e'
 
 [[bench]]
 name = "bulletproofs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate byteorder;
 extern crate curve25519_dalek;
 extern crate rand;
 extern crate sha2;
+extern crate subtle;
 extern crate tiny_keccak;
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #31 

All of the curve operations in the RP code except this one were already done in constant time.

The IPP operations work on public data (the vectors are already blinded), so they don't need to be constant time.