### PR TITLE
Add and test Serde support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,13 @@ version = "0.1.0"
 authors = ["Cathie <cathie@chain.com>"]
 
 [dependencies]
-curve25519-dalek = { version = "^0.16", features = ["nightly"] }
+curve25519-dalek = { version = "^0.16", features = ["serde", "nightly"] }
+subtle = "0.6"
 sha2 = "^0.7"
 rand = "^0.4"
 byteorder = "1.2.1"
-subtle = "0.6"
+serde = "1"
+serde_derive = "1"
 
 [dependencies.tiny-keccak]
 git = 'https://github.com/chain/tiny-keccak.git'
@@ -17,6 +19,7 @@ rev = '5925f81b3c351440283c3328e2345d982aac0f6e'
 [dev-dependencies]
 hex = "^0.3"
 criterion = "0.2"
+bincode = "1"
 
 [features]
 yolocrypto = ["curve25519-dalek/yolocrypto"]

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -17,7 +17,7 @@ use generators::Generators;
 
 use sha2::Sha512;
 
-#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Proof {
     pub(crate) L_vec: Vec<RistrettoPoint>,
     pub(crate) R_vec: Vec<RistrettoPoint>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,14 @@ extern crate sha2;
 extern crate subtle;
 extern crate tiny_keccak;
 
+#[macro_use]
+extern crate serde_derive;
+
 #[cfg(test)]
 extern crate test;
+
+#[cfg(test)]
+extern crate bincode;
 
 mod util;
 


### PR DESCRIPTION
This changes the rangeproof test code to explicitly pass a proof from the
prover to the verifier.

The test code uses bincode for serialization, but the generated proof sizes are
quite bloated (up to 200 bytes larger than necessary).

Some points:

1. Ser/deser is connected with proof verification, since we want to feed the
prover's commitments into the hash.  Right now we decompress and recompress, so
it would probably be better to have the Proof struct hold compressed points.

However, the serde support in `curve25519-dalek` is designed so that the input
validation (are points valid? are scalars canonically encoded?) happens
automatically during deserialization.  The compressed point formats don't
implement `Serialize` or `Deserialize`, so that structs with points and scalars
are either all valid or just return an error.

2. We could write custom Serialize/Deserialize implementations, but it would be
good to have custom types for each resolution of range proof so that we don't
need to encode lengths.

We also would have to make sure that repeat all of the checks correctly.

3. Bincode is designed for IPC, so its goal is just encoding <= memory size,
and I think it encodes lengths as u64s, for instance.  So something like CBOR
might do better.

I feel like the best thing to do is to specialize the `RangeProof` struct by
bitsize, and then provide custom `Serialize`/`Deserialize` implementations that
work on a fixed-size byte array.  This would give compact proof sizes with any
Serde backend.