### PR TITLE
Aggregated range proof enhancements

### DIFF
--- a/src/aggregated_range_proof/dealer.rs
+++ b/src/aggregated_range_proof/dealer.rs
@@ -18,6 +18,12 @@ impl Dealer {
         m: usize,
         transcript: &mut ProofTranscript,
     ) -> Result<DealerAwaitingValueCommitments, &'static str> {
+        if !n.is_power_of_two() {
+            return Err("n is not a power of two")
+        }
+        if !m.is_power_of_two() {
+            return Err("m is not a power of two")
+        }
         transcript.commit_u64(n as u64);
         transcript.commit_u64(m as u64);
         Ok(DealerAwaitingValueCommitments { n, m })

--- a/src/aggregated_range_proof/dealer.rs
+++ b/src/aggregated_range_proof/dealer.rs
@@ -18,11 +18,11 @@ impl Dealer {
         m: usize,
         transcript: &mut ProofTranscript,
     ) -> Result<DealerAwaitingValueCommitments, &'static str> {
-        if !n.is_power_of_two() {
-            return Err("n is not a power of two");
+        if !n.is_power_of_two() || n > 64 {
+            return Err("n is not valid: must be a power of 2, and less than or equal to 64");
         }
         if !m.is_power_of_two() {
-            return Err("m is not a power of two");
+            return Err("m is not valid: must be a power of 2");
         }
         transcript.commit_u64(n as u64);
         transcript.commit_u64(m as u64);

--- a/src/aggregated_range_proof/dealer.rs
+++ b/src/aggregated_range_proof/dealer.rs
@@ -134,14 +134,14 @@ impl DealerAwaitingProofShares {
         proof_shares: &Vec<ProofShare>,
         gen: &GeneratorsView,
         transcript: &mut ProofTranscript,
-    ) -> Result<(Proof, Vec<ProofBlame>), &'static str> {
+    ) -> Result<(Proof, Vec<ProofShareVerifier>), &'static str> {
         if self.m != proof_shares.len() {
             return Err("Length of proof shares doesn't match expected length m");
         }
 
-        let mut proof_blame = Vec::new();
+        let mut share_verifiers = Vec::new();
         for (j, proof_share) in proof_shares.iter().enumerate() {
-            proof_blame.push(ProofBlame {
+            share_verifiers.push(ProofShareVerifier {
                 proof_share: proof_share.clone(),
                 n: self.n,
                 j: j,
@@ -222,6 +222,6 @@ impl DealerAwaitingProofShares {
             ipp_proof,
         };
 
-        Ok((aggregated_proof, proof_blame))
+        Ok((aggregated_proof, share_verifiers))
     }
 }

--- a/src/aggregated_range_proof/dealer.rs
+++ b/src/aggregated_range_proof/dealer.rs
@@ -141,7 +141,7 @@ impl DealerAwaitingProofShares {
 
         let mut proof_blame = Vec::new();
         for (j, proof_share) in proof_shares.iter().enumerate() {
-            proof_blame.push( ProofBlame{
+            proof_blame.push(ProofBlame {
                 proof_share: proof_share.clone(),
                 n: self.n,
                 j: j,

--- a/src/aggregated_range_proof/dealer.rs
+++ b/src/aggregated_range_proof/dealer.rs
@@ -139,9 +139,9 @@ impl DealerAwaitingProofShares {
             );
         }
 
-        for (_j, proof_share) in proof_shares.iter().enumerate() {
+        for (j, proof_share) in proof_shares.iter().enumerate() {
             if proof_share
-                .verify_share(&self.value_challenge, &self.poly_challenge)
+                .verify_share(self.n, j, &self.value_challenge, &self.poly_challenge)
                 .is_err()
             {
                 return Err(

--- a/src/aggregated_range_proof/dealer.rs
+++ b/src/aggregated_range_proof/dealer.rs
@@ -45,9 +45,7 @@ impl DealerAwaitingValueCommitments {
         transcript: &mut ProofTranscript,
     ) -> Result<(DealerAwaitingPolyCommitments, ValueChallenge), &'static str> {
         if self.m != value_commitments.len() {
-            return Err(
-                "Length of value commitments doesn't match expected length m",
-            );
+            return Err("Length of value commitments doesn't match expected length m");
         }
 
         let mut A = RistrettoPoint::identity();
@@ -94,9 +92,7 @@ impl DealerAwaitingPolyCommitments {
         transcript: &mut ProofTranscript,
     ) -> Result<(DealerAwaitingProofShares, PolyChallenge), &'static str> {
         if self.m != poly_commitments.len() {
-            return Err(
-                "Length of poly commitments doesn't match expected length m",
-            );
+            return Err("Length of poly commitments doesn't match expected length m");
         }
 
         // Commit sums of T1s and T2s.
@@ -140,9 +136,7 @@ impl DealerAwaitingProofShares {
         transcript: &mut ProofTranscript,
     ) -> Result<(Proof, Vec<ProofBlame>), &'static str> {
         if self.m != proof_shares.len() {
-            return Err(
-                "Length of proof shares doesn't match expected length m",
-            );
+            return Err("Length of proof shares doesn't match expected length m");
         }
 
         let mut proof_blame = Vec::new();

--- a/src/aggregated_range_proof/dealer.rs
+++ b/src/aggregated_range_proof/dealer.rs
@@ -19,10 +19,10 @@ impl Dealer {
         transcript: &mut ProofTranscript,
     ) -> Result<DealerAwaitingValueCommitments, &'static str> {
         if !n.is_power_of_two() {
-            return Err("n is not a power of two")
+            return Err("n is not a power of two");
         }
         if !m.is_power_of_two() {
-            return Err("m is not a power of two")
+            return Err("m is not a power of two");
         }
         transcript.commit_u64(n as u64);
         transcript.commit_u64(m as u64);

--- a/src/aggregated_range_proof/messages.rs
+++ b/src/aggregated_range_proof/messages.rs
@@ -120,7 +120,6 @@ impl ProofShare {
     }
 }
 
-// TODO: rename this to something that sounds less awkward
 pub struct ProofBlame {
     pub proof_share: ProofShare,
     pub n: usize,
@@ -130,6 +129,7 @@ pub struct ProofBlame {
 }
 
 impl ProofBlame {
+    /// Returns whether the proof share is valid (Ok) or invalid (Err)
     pub fn blame(&self) -> Result<(), &'static str> {
         self.proof_share
             .verify_share(self.n, self.j, &self.value_challenge, &self.poly_challenge)

--- a/src/aggregated_range_proof/messages.rs
+++ b/src/aggregated_range_proof/messages.rs
@@ -73,7 +73,6 @@ impl ProofShare {
     		return Err("Inner product of l_vec and r_vec is not equal to t_x")
     	}
 
-
     	let g = self.l_vec.iter().map(|l_i| minus_z - l_i );
     	let h = self.r_vec.iter()
     		.zip(util::exp_iter(Scalar::from_u64(2)))
@@ -83,7 +82,6 @@ impl ProofShare {
     			exp_y_inv * y_jn_inv * (- r_i) + 
     			exp_y_inv * y_jn_inv * (zz * z_j * exp_2)
     		);
-    	
     	let P_check = ristretto::vartime::multiscalar_mul(
     		iter::once(Scalar::one())
     			.chain(iter::once(x))
@@ -97,16 +95,13 @@ impl ProofShare {
     			.chain(gen.G.iter())
     			.chain(gen.H.iter())
     	);
-
     	if !P_check.is_identity() {
     		return Err("P check is not equal to zero")
     	}
 
 	    let sum_of_powers_of_y = sum_of_powers_of(&y, n);
 	    let sum_of_powers_of_2 = sum_of_powers_of(&Scalar::from_u64(2), n);
-
     	let delta = (z - zz) * sum_of_powers_of_y * y_jn - z * zz * sum_of_powers_of_2 * z_j;
-
     	let t_check = ristretto::vartime::multiscalar_mul(
     		iter::once(zz * z_j)
     		.chain(iter::once(x))
@@ -119,12 +114,26 @@ impl ProofShare {
     		.chain(iter::once(&gen.pedersen_generators.B))
     		.chain(iter::once(&gen.pedersen_generators.B_blinding))
     	);
-
     	if !t_check.is_identity() {
     		return Err("t check is not equal to zero")
     	}
 
         Ok(())
+    }
+}
+
+// TODO: rename this to something that sounds less awkward
+pub struct ProofBlame {
+    pub proof_share: ProofShare,
+    pub n: usize,
+    pub j: usize,
+    pub value_challenge: ValueChallenge,
+    pub poly_challenge: PolyChallenge,
+}
+
+impl ProofBlame {
+    pub fn blame(&self) -> Result<(), &'static str> {
+        self.proof_share.verify_share(self.n, self.j, &self.value_challenge, &self.poly_challenge)
     }
 }
 

--- a/src/aggregated_range_proof/messages.rs
+++ b/src/aggregated_range_proof/messages.rs
@@ -54,69 +54,67 @@ impl ProofShare {
         value_challenge: &ValueChallenge,
         poly_challenge: &PolyChallenge,
     ) -> Result<(), &'static str> {
-    	use generators::{Generators, PedersenGenerators};
-    	let generators = Generators::new(PedersenGenerators::default(), n, j+1);
-    	let gen = generators.share(j);
+        use generators::{Generators, PedersenGenerators};
+        let generators = Generators::new(PedersenGenerators::default(), n, j + 1);
+        let gen = generators.share(j);
 
-    	// renaming and precomputation
-    	let x = poly_challenge.x;
-    	let y = value_challenge.y;
-    	let z = value_challenge.z;
+        // renaming and precomputation
+        let x = poly_challenge.x;
+        let y = value_challenge.y;
+        let z = value_challenge.z;
         let zz = z * z;
         let minus_z = -z;
-	    let z_j = util::exp_iter(z).take(j+1).last().unwrap(); // z^j
-	    let y_jn = util::exp_iter(y).take(j*n+1).last().unwrap(); // y^(j*n)
-	    let y_jn_inv = y_jn.invert(); // y^(-j*n)
-	    let y_inv = y.invert(); // y^(-1)
+        let z_j = util::exp_iter(z).take(j + 1).last().unwrap(); // z^j
+        let y_jn = util::exp_iter(y).take(j * n + 1).last().unwrap(); // y^(j*n)
+        let y_jn_inv = y_jn.invert(); // y^(-j*n)
+        let y_inv = y.invert(); // y^(-1)
 
-    	if self.t_x != inner_product_proof::inner_product(&self.l_vec, &self.r_vec) {
-    		return Err("Inner product of l_vec and r_vec is not equal to t_x")
-    	}
+        if self.t_x != inner_product_proof::inner_product(&self.l_vec, &self.r_vec) {
+            return Err("Inner product of l_vec and r_vec is not equal to t_x");
+        }
 
-    	let g = self.l_vec.iter().map(|l_i| minus_z - l_i );
-    	let h = self.r_vec.iter()
-    		.zip(util::exp_iter(Scalar::from_u64(2)))
-    		.zip(util::exp_iter(y_inv))
-    		.map(|((r_i, exp_2), exp_y_inv)| 
-    			z + 
-    			exp_y_inv * y_jn_inv * (- r_i) + 
-    			exp_y_inv * y_jn_inv * (zz * z_j * exp_2)
-    		);
-    	let P_check = ristretto::vartime::multiscalar_mul(
-    		iter::once(Scalar::one())
-    			.chain(iter::once(x))
-    			.chain(iter::once(- self.e_blinding))
-    			.chain(g)
-    			.chain(h),
+        let g = self.l_vec.iter().map(|l_i| minus_z - l_i);
+        let h = self.r_vec
+            .iter()
+            .zip(util::exp_iter(Scalar::from_u64(2)))
+            .zip(util::exp_iter(y_inv))
+            .map(|((r_i, exp_2), exp_y_inv)| {
+                z + exp_y_inv * y_jn_inv * (-r_i) + exp_y_inv * y_jn_inv * (zz * z_j * exp_2)
+            });
+        let P_check = ristretto::vartime::multiscalar_mul(
+            iter::once(Scalar::one())
+                .chain(iter::once(x))
+                .chain(iter::once(-self.e_blinding))
+                .chain(g)
+                .chain(h),
+            iter::once(&self.value_commitment.A)
+                .chain(iter::once(&self.value_commitment.S))
+                .chain(iter::once(&gen.pedersen_generators.B_blinding))
+                .chain(gen.G.iter())
+                .chain(gen.H.iter()),
+        );
+        if !P_check.is_identity() {
+            return Err("P check is not equal to zero");
+        }
 
-    		iter::once(&self.value_commitment.A)
-    			.chain(iter::once(&self.value_commitment.S))
-    			.chain(iter::once(&gen.pedersen_generators.B_blinding))
-    			.chain(gen.G.iter())
-    			.chain(gen.H.iter())
-    	);
-    	if !P_check.is_identity() {
-    		return Err("P check is not equal to zero")
-    	}
-
-	    let sum_of_powers_of_y = sum_of_powers_of(&y, n);
-	    let sum_of_powers_of_2 = sum_of_powers_of(&Scalar::from_u64(2), n);
-    	let delta = (z - zz) * sum_of_powers_of_y * y_jn - z * zz * sum_of_powers_of_2 * z_j;
-    	let t_check = ristretto::vartime::multiscalar_mul(
-    		iter::once(zz * z_j)
-    		.chain(iter::once(x))
-    		.chain(iter::once(x * x))
-    		.chain(iter::once(delta - self.t_x))
-    		.chain(iter::once(-self.t_x_blinding)),
-    		iter::once(&self.value_commitment.V)
-    		.chain(iter::once(&self.poly_commitment.T_1))
-    		.chain(iter::once(&self.poly_commitment.T_2))
-    		.chain(iter::once(&gen.pedersen_generators.B))
-    		.chain(iter::once(&gen.pedersen_generators.B_blinding))
-    	);
-    	if !t_check.is_identity() {
-    		return Err("t check is not equal to zero")
-    	}
+        let sum_of_powers_of_y = sum_of_powers_of(&y, n);
+        let sum_of_powers_of_2 = sum_of_powers_of(&Scalar::from_u64(2), n);
+        let delta = (z - zz) * sum_of_powers_of_y * y_jn - z * zz * sum_of_powers_of_2 * z_j;
+        let t_check = ristretto::vartime::multiscalar_mul(
+            iter::once(zz * z_j)
+                .chain(iter::once(x))
+                .chain(iter::once(x * x))
+                .chain(iter::once(delta - self.t_x))
+                .chain(iter::once(-self.t_x_blinding)),
+            iter::once(&self.value_commitment.V)
+                .chain(iter::once(&self.poly_commitment.T_1))
+                .chain(iter::once(&self.poly_commitment.T_2))
+                .chain(iter::once(&gen.pedersen_generators.B))
+                .chain(iter::once(&gen.pedersen_generators.B_blinding)),
+        );
+        if !t_check.is_identity() {
+            return Err("t check is not equal to zero");
+        }
 
         Ok(())
     }
@@ -133,7 +131,8 @@ pub struct ProofBlame {
 
 impl ProofBlame {
     pub fn blame(&self) -> Result<(), &'static str> {
-        self.proof_share.verify_share(self.n, self.j, &self.value_challenge, &self.poly_challenge)
+        self.proof_share
+            .verify_share(self.n, self.j, &self.value_challenge, &self.poly_challenge)
     }
 }
 
@@ -258,7 +257,7 @@ impl Proof {
 
 /// Compute delta(y,z) = (z - z^2)<1^n*m, y^n*m> + z^3 <1, 2^n*m> * \sum_j=0^(m-1) z^j
 fn delta(n: usize, m: usize, y: &Scalar, z: &Scalar) -> Scalar {
-    let sum_y = sum_of_powers_of(y, n*m);
+    let sum_y = sum_of_powers_of(y, n * m);
     let sum_2 = sum_of_powers_of(&Scalar::from_u64(2), n);
     let sum_z = sum_of_powers_of(z, m);
 
@@ -267,7 +266,7 @@ fn delta(n: usize, m: usize, y: &Scalar, z: &Scalar) -> Scalar {
 
 // XXX this could be more efficient, esp for powers of 2
 fn sum_of_powers_of(a: &Scalar, to: usize) -> Scalar {
-	util::exp_iter(*a)
-		.take(to)
-		.fold(Scalar::zero(), |acc, x| acc + x)
+    util::exp_iter(*a)
+        .take(to)
+        .fold(Scalar::zero(), |acc, x| acc + x)
 }

--- a/src/aggregated_range_proof/messages.rs
+++ b/src/aggregated_range_proof/messages.rs
@@ -120,7 +120,7 @@ impl ProofShare {
     }
 }
 
-pub struct ProofBlame {
+pub struct ProofShareVerifier {
     pub proof_share: ProofShare,
     pub n: usize,
     pub j: usize,
@@ -128,9 +128,9 @@ pub struct ProofBlame {
     pub poly_challenge: PolyChallenge,
 }
 
-impl ProofBlame {
+impl ProofShareVerifier {
     /// Returns whether the proof share is valid (Ok) or invalid (Err)
-    pub fn blame(&self) -> Result<(), &'static str> {
+    pub fn verify_share(&self) -> Result<(), &'static str> {
         self.proof_share
             .verify_share(self.n, self.j, &self.value_challenge, &self.poly_challenge)
     }

--- a/src/aggregated_range_proof/messages.rs
+++ b/src/aggregated_range_proof/messages.rs
@@ -46,7 +46,16 @@ pub struct ProofShare {
     pub r_vec: Vec<Scalar>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+impl ProofShare {
+    pub fn verify_share(
+        &self,
+        value_challenge: &ValueChallenge,
+        poly_challenge: &PolyChallenge,
+    ) -> Result<(), ()> {
+        Ok(())
+    }
+}
+
 pub struct Proof {
     pub n: usize,
     /// Commitment to the value

--- a/src/aggregated_range_proof/messages.rs
+++ b/src/aggregated_range_proof/messages.rs
@@ -97,9 +97,9 @@ impl ProofShare {
             return Err("P check is not equal to zero");
         }
 
-        let sum_of_powers_of_y = sum_of_powers_of(&y, n);
-        let sum_of_powers_of_2 = sum_of_powers_of(&Scalar::from_u64(2), n);
-        let delta = (z - zz) * sum_of_powers_of_y * y_jn - z * zz * sum_of_powers_of_2 * z_j;
+        let sum_of_powers_y = util::sum_of_powers(&y, n);
+        let sum_of_powers_2 = util::sum_of_powers(&Scalar::from_u64(2), n);
+        let delta = (z - zz) * sum_of_powers_y * y_jn - z * zz * sum_of_powers_2 * z_j;
         let t_check = ristretto::vartime::multiscalar_mul(
             iter::once(zz * z_j)
                 .chain(iter::once(x))
@@ -257,16 +257,9 @@ impl Proof {
 
 /// Compute delta(y,z) = (z - z^2)<1^n*m, y^n*m> + z^3 <1, 2^n*m> * \sum_j=0^(m-1) z^j
 fn delta(n: usize, m: usize, y: &Scalar, z: &Scalar) -> Scalar {
-    let sum_y = sum_of_powers_of(y, n * m);
-    let sum_2 = sum_of_powers_of(&Scalar::from_u64(2), n);
-    let sum_z = sum_of_powers_of(z, m);
+    let sum_y = util::sum_of_powers(y, n * m);
+    let sum_2 = util::sum_of_powers(&Scalar::from_u64(2), n);
+    let sum_z = util::sum_of_powers(z, m);
 
     (z - z * z) * sum_y - z * z * z * sum_2 * sum_z
-}
-
-// XXX this could be more efficient, esp for powers of 2
-fn sum_of_powers_of(a: &Scalar, to: usize) -> Scalar {
-    util::exp_iter(*a)
-        .take(to)
-        .fold(Scalar::zero(), |acc, x| acc + x)
 }

--- a/src/aggregated_range_proof/mod.rs
+++ b/src/aggregated_range_proof/mod.rs
@@ -64,7 +64,6 @@ mod tests {
             .receive_shares(
                 &proof_shares,
                 &generators.all(),
-                value_challenge.y,
                 &mut transcript,
             )
             .unwrap()

--- a/src/aggregated_range_proof/mod.rs
+++ b/src/aggregated_range_proof/mod.rs
@@ -66,7 +66,7 @@ mod tests {
                 &generators.all(),
                 &mut transcript,
             )
-            .unwrap()
+            .unwrap().0
     }
 
     fn test_u32(m: usize) {

--- a/src/aggregated_range_proof/mod.rs
+++ b/src/aggregated_range_proof/mod.rs
@@ -17,7 +17,11 @@ mod tests {
     use super::messages::*;
     use super::party::*;
 
-    fn create_multi<R: Rng>(rng: &mut R, values: Vec<u64>, n: usize) -> (Proof, Vec<ProofBlame>) {
+    fn create_multi<R: Rng>(
+        rng: &mut R,
+        values: Vec<u64>,
+        n: usize,
+    ) -> (Proof, Vec<ProofShareVerifier>) {
         use generators::{Generators, PedersenGenerators};
 
         let m = values.len();
@@ -71,11 +75,11 @@ mod tests {
             .map(|()| rng.next_u32() as u64)
             .take(m)
             .collect();
-        let (proof, proof_blames) = create_multi(&mut rng, v, 32);
+        let (proof, share_verifiers) = create_multi(&mut rng, v, 32);
         assert!(proof.verify(&mut rng, &mut transcript).is_ok());
-        proof_blames
+        share_verifiers
             .iter()
-            .map(|pb| assert!(pb.blame().is_ok()))
+            .map(|sv| assert!(sv.verify_share().is_ok()))
             .last();
     }
 
@@ -84,11 +88,11 @@ mod tests {
         let mut transcript = ProofTranscript::new(b"AggregatedRangeProofTest");
 
         let v: Vec<u64> = iter::repeat(()).map(|()| rng.next_u64()).take(m).collect();
-        let (proof, proof_blames) = create_multi(&mut rng, v, 64);
+        let (proof, share_verifiers) = create_multi(&mut rng, v, 64);
         assert!(proof.verify(&mut rng, &mut transcript).is_ok());
-        proof_blames
+        share_verifiers
             .iter()
-            .map(|pb| assert!(pb.blame().is_ok()))
+            .map(|sv| assert!(sv.verify_share().is_ok()))
             .last();
     }
 

--- a/src/aggregated_range_proof/mod.rs
+++ b/src/aggregated_range_proof/mod.rs
@@ -28,7 +28,7 @@ mod tests {
             .iter()
             .map(|&v| {
                 let v_blinding = Scalar::random(rng);
-                Party::new(v, v_blinding, n, &generators)
+                Party::new(v, v_blinding, n, &generators).unwrap()
             })
             .collect();
 
@@ -39,9 +39,7 @@ mod tests {
             .enumerate()
             .map(|(j, p)| p.assign_position(j, rng))
             .unzip();
-
-        // let (a, b) = dealer.receive_value_commitments(&mut transcript, &value_commitments).unwrap();
-
+            
         let (dealer, value_challenge) = dealer
             .receive_value_commitments(&value_commitments, &mut transcript)
             .unwrap();

--- a/src/aggregated_range_proof/mod.rs
+++ b/src/aggregated_range_proof/mod.rs
@@ -61,12 +61,9 @@ mod tests {
             .collect();
 
         dealer
-            .receive_shares(
-                &proof_shares,
-                &generators.all(),
-                &mut transcript,
-            )
-            .unwrap().0
+            .receive_shares(&proof_shares, &generators.all(), &mut transcript)
+            .unwrap()
+            .0
     }
 
     fn test_u32(m: usize) {

--- a/src/aggregated_range_proof/mod.rs
+++ b/src/aggregated_range_proof/mod.rs
@@ -32,7 +32,7 @@ mod tests {
             })
             .collect();
 
-        let dealer = Dealer::new(&mut transcript, n, m);
+        let dealer = Dealer::new(n, m, &mut transcript).unwrap();
 
         let (parties, value_commitments): (Vec<_>, Vec<_>) = parties
             .into_iter()
@@ -40,28 +40,34 @@ mod tests {
             .map(|(j, p)| p.assign_position(j, rng))
             .unzip();
 
-        let (dealer, value_challenge) =
-            dealer.receive_value_commitments(&mut transcript, &value_commitments);
+        // let (a, b) = dealer.receive_value_commitments(&mut transcript, &value_commitments).unwrap();
+
+        let (dealer, value_challenge) = dealer
+            .receive_value_commitments(&value_commitments, &mut transcript)
+            .unwrap();
 
         let (parties, poly_commitments): (Vec<_>, Vec<_>) = parties
             .into_iter()
             .map(|p| p.apply_challenge(&value_challenge, rng))
             .unzip();
 
-        let (dealer, poly_challenge) =
-            dealer.receive_poly_commitments(&mut transcript, &poly_commitments);
+        let (dealer, poly_challenge) = dealer
+            .receive_poly_commitments(&poly_commitments, &mut transcript)
+            .unwrap();
 
         let proof_shares: Vec<ProofShare> = parties
             .into_iter()
             .map(|p| p.apply_challenge(&poly_challenge))
             .collect();
 
-        dealer.receive_shares(
-            &mut transcript,
-            &proof_shares,
-            &generators.all(),
-            value_challenge.y,
-        )
+        dealer
+            .receive_shares(
+                &proof_shares,
+                &generators.all(),
+                value_challenge.y,
+                &mut transcript,
+            )
+            .unwrap()
     }
 
     fn test_u32(m: usize) {

--- a/src/aggregated_range_proof/mod.rs
+++ b/src/aggregated_range_proof/mod.rs
@@ -8,7 +8,7 @@ pub mod party;
 mod tests {
     use std::iter;
 
-    use rand::{Rng, OsRng};
+    use rand::{OsRng, Rng};
 
     use curve25519_dalek::scalar::Scalar;
     use proof_transcript::ProofTranscript;

--- a/src/aggregated_range_proof/mod.rs
+++ b/src/aggregated_range_proof/mod.rs
@@ -39,7 +39,7 @@ mod tests {
             .enumerate()
             .map(|(j, p)| p.assign_position(j, rng))
             .unzip();
-            
+
         let (dealer, value_challenge) = dealer
             .receive_value_commitments(&value_commitments, &mut transcript)
             .unwrap();

--- a/src/aggregated_range_proof/party.rs
+++ b/src/aggregated_range_proof/party.rs
@@ -19,7 +19,7 @@ impl Party {
         generators: &Generators,
     ) -> Result<PartyAwaitingPosition, &'static str> {
         if !n.is_power_of_two() {
-            return Err("n is not a power of two")
+            return Err("n is not a power of two");
         }
         let V = generators
             .share(0)

--- a/src/aggregated_range_proof/party.rs
+++ b/src/aggregated_range_proof/party.rs
@@ -18,8 +18,8 @@ impl Party {
         n: usize,
         generators: &Generators,
     ) -> Result<PartyAwaitingPosition, &'static str> {
-        if !n.is_power_of_two() {
-            return Err("n is not a power of two");
+        if !n.is_power_of_two() || n > 64 {
+            return Err("n is not valid: must be a power of 2, and less than or equal to 64");
         }
         let V = generators
             .share(0)

--- a/src/aggregated_range_proof/party.rs
+++ b/src/aggregated_range_proof/party.rs
@@ -17,19 +17,22 @@ impl Party {
         v_blinding: Scalar,
         n: usize,
         generators: &Generators,
-    ) -> PartyAwaitingPosition {
+    ) -> Result<PartyAwaitingPosition, &'static str> {
+        if !n.is_power_of_two() {
+            return Err("n is not a power of two")
+        }
         let V = generators
             .share(0)
             .pedersen_generators
             .commit(Scalar::from_u64(v), v_blinding);
 
-        PartyAwaitingPosition {
+        Ok(PartyAwaitingPosition {
             generators: generators,
             n,
             v,
             v_blinding,
             V,
-        }
+        })
     }
 }
 
@@ -103,7 +106,7 @@ pub struct PartyAwaitingValueChallenge<'a> {
     v: u64,
     v_blinding: Scalar,
 
-    j: usize, // index of the party, 1..m as in original paper
+    j: usize,
     generators: &'a Generators,
     value_commitment: ValueCommitment,
     a_blinding: Scalar,
@@ -194,7 +197,6 @@ pub struct PartyAwaitingPolyChallenge {
 
 impl PartyAwaitingPolyChallenge {
     pub fn apply_challenge(self, pc: &PolyChallenge) -> ProofShare {
-        // Generate final values for proof (line 55-60)
         let t_blinding_poly = util::Poly2(
             self.z * self.z * self.offset_z * self.v_blinding,
             self.t_1_blinding,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,13 @@ mod util;
 
 #[doc(include = "../docs/notes.md")]
 mod notes {}
+
 mod generators;
 mod inner_product_proof;
 mod proof_transcript;
 mod range_proof;
 pub mod aggregated_range_proof;
 
-pub use aggregated_range_proof::*;
 pub use generators::{Generators, GeneratorsView, PedersenGenerators};
 pub use proof_transcript::ProofTranscript;
 pub use range_proof::RangeProof;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ mod util;
 
 #[doc(include = "../docs/notes.md")]
 mod notes {}
-
 pub mod aggregated_range_proof;
 mod generators;
 mod inner_product_proof;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ mod proof_transcript;
 mod range_proof;
 pub mod aggregated_range_proof;
 
+pub use aggregated_range_proof::*;
 pub use generators::{Generators, GeneratorsView, PedersenGenerators};
 pub use proof_transcript::ProofTranscript;
 pub use range_proof::RangeProof;
-pub use aggregated_range_proof::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,11 @@ mod util;
 #[doc(include = "../docs/notes.md")]
 mod notes {}
 
+pub mod aggregated_range_proof;
 mod generators;
 mod inner_product_proof;
 mod proof_transcript;
 mod range_proof;
-pub mod aggregated_range_proof;
 
 pub use generators::{Generators, GeneratorsView, PedersenGenerators};
 pub use proof_transcript::ProofTranscript;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,3 +37,4 @@ pub mod aggregated_range_proof;
 pub use generators::{Generators, GeneratorsView, PedersenGenerators};
 pub use proof_transcript::ProofTranscript;
 pub use range_proof::RangeProof;
+pub use aggregated_range_proof::*;


### PR DESCRIPTION
Things added:
- [x] state outputs are Results, to allow for error returns
- [x] individual proof share validity checking
- [x] ProofBlame struct for ^ and tests for ProofBlame
- [x] check that m and n are valid powers of 2 and that all dealer states take in `m` items