### PR TITLE
Add a `SinglePartyAggregator` and refactor test code

### DIFF
--- a/src/aggregated_range_proof/dealer.rs
+++ b/src/aggregated_range_proof/dealer.rs
@@ -134,7 +134,7 @@ impl DealerAwaitingProofShares {
         proof_shares: &Vec<ProofShare>,
         gen: &GeneratorsView,
         transcript: &mut ProofTranscript,
-    ) -> Result<(Proof, Vec<ProofShareVerifier>), &'static str> {
+    ) -> Result<(AggregatedProof, Vec<ProofShareVerifier>), &'static str> {
         if self.m != proof_shares.len() {
             return Err("Length of proof shares doesn't match expected length m");
         }
@@ -209,7 +209,7 @@ impl DealerAwaitingProofShares {
             r_vec.clone(),
         );
 
-        let aggregated_proof = Proof {
+        let aggregated_proof = AggregatedProof {
             n: self.n,
             value_commitments,
             A,

--- a/src/aggregated_range_proof/messages.rs
+++ b/src/aggregated_range_proof/messages.rs
@@ -136,7 +136,7 @@ impl ProofShareVerifier {
     }
 }
 
-pub struct Proof {
+pub struct AggregatedProof {
     pub n: usize,
     /// Commitment to the value
     // XXX this should not be included, so that we can prove about existing commitments
@@ -160,7 +160,7 @@ pub struct Proof {
     pub ipp_proof: inner_product_proof::InnerProductProof,
 }
 
-impl Proof {
+impl AggregatedProof {
     pub fn verify<R: Rng>(&self, rng: &mut R, transcript: &mut ProofTranscript) -> Result<(), ()> {
         use generators::{Generators, PedersenGenerators};
 

--- a/src/aggregated_range_proof/messages.rs
+++ b/src/aggregated_range_proof/messages.rs
@@ -136,6 +136,7 @@ impl ProofShareVerifier {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AggregatedProof {
     pub n: usize,
     /// Commitment to the value

--- a/src/aggregated_range_proof/mod.rs
+++ b/src/aggregated_range_proof/mod.rs
@@ -108,9 +108,7 @@ mod tests {
             let mut rng = OsRng::new().unwrap();
             let mut transcript = ProofTranscript::new(b"AggregatedRangeProofTest");
 
-            // XXX this takes max = 2^{n-1} to avoid problems at n = 64
-            // would be better to use max = 2^n - 1
-            let (min, max) = (0u64, 1 << (n - 1));
+            let (min, max) = (0u64, ((1u128 << n) - 1) as u64);
             let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min, max)).collect();
 
             let proof = SinglePartyAggregator::generate_proof(

--- a/src/aggregated_range_proof/mod.rs
+++ b/src/aggregated_range_proof/mod.rs
@@ -21,7 +21,7 @@ mod tests {
         rng: &mut R,
         values: Vec<u64>,
         n: usize,
-    ) -> (Proof, Vec<ProofShareVerifier>) {
+    ) -> (AggregatedProof, Vec<ProofShareVerifier>) {
         use generators::{Generators, PedersenGenerators};
 
         let m = values.len();


### PR DESCRIPTION
- renames `Proof` to `AggregatedProof`
- moves the orchestration logic from the tests into a convenience `SinglePartyAggregator`
- refactors the test code to perform a full round trip of create → serialize → deserialize → verify