### PR TITLE
Fix the build and add benches to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rust:
 env:
   - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES=''
   - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='yolocrypto'
+  # run cargo bench with a filter that matches no benchmarks.
+  # this ensures the benchmarks build but doesn't run them on the CI server.
+  - TEST_COMMAND=bench EXTRA_FLAGS='"DONTRUNBENCHMARKS"' FEATURES='yolocrypto'
 
 script:
   - cargo $TEST_COMMAND --features="$FEATURES" $EXTRA_FLAGS


### PR DESCRIPTION
#76 broke the benchmarks because they weren't tested by CI.

This adds an empty `cargo bench` run to CI, so that no benches are run, but the benchmarks are compiled.