### PR TITLE
Refactor Party into enum, add Clone impl

### DIFF
--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -1,8 +1,8 @@
-//! The `party` module contains the API for the party state while the party is 
-//! engaging in an aggregated multiparty computation protocol. 
+//! The `party` module contains the API for the party state while the party is
+//! engaging in an aggregated multiparty computation protocol.
 //!
 //! For more explanation of how the `dealer`, `party`, and `messages` modules orchestrate the protocol execution, see
-//! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol). 
+//! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol).
 
 use curve25519_dalek::ristretto;
 use curve25519_dalek::ristretto::RistrettoPoint;
@@ -14,16 +14,66 @@ use util;
 
 use super::messages::*;
 
-/// Party is an entry-point API for setting up a party.
-pub struct Party {}
 
-impl Party {
+enum PartyState<'a> {
+    AwaitingPosition {
+        generators: &'a Generators,
+        n: usize,
+        v: u64,
+        v_blinding: Scalar,
+        V: RistrettoPoint,
+    },
+    /// When party knows its position (`j`), it can produce commitments
+    /// to all bits of the value and necessary blinding factors.
+    AwaitingValueChallenge {
+        n: usize, // bitsize of the range
+        v: u64,
+        v_blinding: Scalar,
+        j: usize,
+        generators: &'a Generators,
+        value_commitment: ValueCommitment,
+        a_blinding: Scalar,
+        s_blinding: Scalar,
+        s_L: Vec<Scalar>,
+        s_R: Vec<Scalar>,
+    },
+    AwaitingPolyChallenge {
+        value_commitment: ValueCommitment,
+        poly_commitment: PolyCommitment,
+        z: Scalar,
+        offset_z: Scalar,
+        l_poly: util::VecPoly1,
+        r_poly: util::VecPoly1,
+        t_poly: util::Poly2,
+        v_blinding: Scalar,
+        a_blinding: Scalar,
+        s_blinding: Scalar,
+        t_1_blinding: Scalar,
+        t_2_blinding: Scalar,
+    },
+    Invalid
+}
+
+/// Party is an entry-point API for setting up a party.
+pub struct Party<'a> {
+    state: PartyState<'a>
+}
+
+impl<'a> Clone for Party<'a> {
+    fn clone(&self) -> Party<'a> {
+        Party {
+            state: PartyState::Invalid
+        }
+    }
+}
+
+impl<'a> Party<'a> {
     pub fn new(
         v: u64,
         v_blinding: Scalar,
         n: usize,
         generators: &Generators,
-    ) -> Result<PartyAwaitingPosition, &'static str> {
+    ) -> Result<Party, &'static str> {
         if !n.is_power_of_two() || n > 64 {
             return Err("n is not valid: must be a power of 2, and less than or equal to 64");
         }
@@ -31,53 +81,49 @@ impl Party {
             .share(0)
             .pedersen_generators
             .commit(Scalar::from_u64(v), v_blinding);
-
-        Ok(PartyAwaitingPosition {
-            generators: generators,
-            n,
-            v,
-            v_blinding,
-            V,
-        })
+        let initial_party = Party {
+            state: PartyState::AwaitingPosition { generators: generators, n, v, v_blinding, V }
+        };
+        Ok(initial_party)
     }
-}
 
-/// As party awaits its position, they only know their value and desired bit-size of the proof.
-pub struct PartyAwaitingPosition<'a> {
-    generators: &'a Generators,
-    n: usize,
-    v: u64,
-    v_blinding: Scalar,
-    V: RistrettoPoint,
-}
-
-impl<'a> PartyAwaitingPosition<'a> {
     /// Assigns the position to a party,
     /// at which point the party knows its generators.
     pub fn assign_position<R: Rng>(
         self,
         j: usize,
         mut rng: &mut R,
-    ) -> (PartyAwaitingValueChallenge<'a>, ValueCommitment) {
-        let gen_share = self.generators.share(j);
+    ) -> Result<(Party<'a>, ValueCommitment), &'static str> {
+        let (generators, n, v, v_blinding, V) = match self.state {
+            PartyState::AwaitingPosition {
+                generators,
+                n,
+                v,
+                v_blinding,
+                V
+            } => (generators, n, v, v_blinding, V),
+            _ => return Err("invalid state")
+        };
+
+        let gen_share = generators.share(j);
 
         let a_blinding = Scalar::random(&mut rng);
         // Compute A = <a_L, G> + <a_R, H> + a_blinding * B_blinding
         let mut A = gen_share.pedersen_generators.B_blinding * a_blinding;
 
         use subtle::{Choice, ConditionallyAssignable};
-        for i in 0..self.n {
+        for i in 0..n {
             // If v_i = 0, we add a_L[i] * G[i] + a_R[i] * H[i] = - H[i]
             // If v_i = 1, we add a_L[i] * G[i] + a_R[i] * H[i] =   G[i]
-            let v_i = Choice::from(((self.v >> i) & 1) as u8);
+            let v_i = Choice::from(((v >> i) & 1) as u8);
             let mut point = -gen_share.H[i];
             point.conditional_assign(&gen_share.G[i], v_i);
             A += point;
         }
 
         let s_blinding = Scalar::random(&mut rng);
-        let s_L: Vec<Scalar> = (0..self.n).map(|_| Scalar::random(&mut rng)).collect();
-        let s_R: Vec<Scalar> = (0..self.n).map(|_| Scalar::random(&mut rng)).collect();
+        let s_L: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
+        let s_R: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
 
         // Compute S = <s_L, G> + <s_R, H> + s_blinding * B_blinding
         let S = ristretto::multiscalar_mul(
@@ -88,12 +134,12 @@ impl<'a> PartyAwaitingPosition<'a> {
         );
 
         // Return next state and all commitments
-        let value_commitment = ValueCommitment { V: self.V, A, S };
-        let next_state = PartyAwaitingValueChallenge {
-            n: self.n,
-            v: self.v,
-            v_blinding: self.v_blinding,
-            generators: self.generators,
+        let value_commitment = ValueCommitment { V: V, A, S };
+        let next_state = PartyState::AwaitingValueChallenge {
+            n: n,
+            v: v,
+            v_blinding: v_blinding,
+            generators: generators,
             j,
             value_commitment,
             a_blinding,
@@ -101,35 +147,34 @@ impl<'a> PartyAwaitingPosition<'a> {
             s_L,
             s_R,
         };
-        (next_state, value_commitment)
+        Ok((Party{state:next_state}, value_commitment))
     }
-}
 
-/// When party knows its position (`j`), it can produce commitments
-/// to all bits of the value and necessary blinding factors.
-pub struct PartyAwaitingValueChallenge<'a> {
-    n: usize, // bitsize of the range
-    v: u64,
-    v_blinding: Scalar,
-
-    j: usize,
-    generators: &'a Generators,
-    value_commitment: ValueCommitment,
-    a_blinding: Scalar,
-    s_blinding: Scalar,
-    s_L: Vec<Scalar>,
-    s_R: Vec<Scalar>,
-}
-
-impl<'a> PartyAwaitingValueChallenge<'a> {
-    pub fn apply_challenge<R: Rng>(
+    pub fn apply_value_challenge<R: Rng>(
         self,
         vc: &ValueChallenge,
         rng: &mut R,
-    ) -> (PartyAwaitingPolyChallenge, PolyCommitment) {
-        let n = self.n;
-        let offset_y = util::scalar_exp_vartime(&vc.y, (self.j * n) as u64);
-        let offset_z = util::scalar_exp_vartime(&vc.z, self.j as u64);
+    ) -> Result<(Party<'a>, PolyCommitment), &'static str> {
+        let (n, v, v_blinding, j, generators, value_commitment,
+             a_blinding, s_blinding, s_L, s_R)
+             = match self.state {
+                PartyState::AwaitingValueChallenge {
+                    n,
+                    v,
+                    v_blinding,
+                    j,
+                    generators,
+                    value_commitment,
+                    a_blinding,
+                    s_blinding,
+                    s_L,
+                    s_R
+                } => (n, v, v_blinding, j, generators, value_commitment,
+                      a_blinding, s_blinding, s_L, s_R),
+                _ => return Err("invalid state")
+        };
+        let offset_y = util::scalar_exp_vartime(&vc.y, (j * n) as u64);
+        let offset_z = util::scalar_exp_vartime(&vc.z, j as u64);
 
         // Calculate t by calculating vectors l0, l1, r0, r1 and multiplying
         let mut l_poly = util::VecPoly1::zero(n);
@@ -139,13 +184,13 @@ impl<'a> PartyAwaitingValueChallenge<'a> {
         let mut exp_y = offset_y; // start at y^j
         let mut exp_2 = Scalar::one(); // start at 2^0 = 1
         for i in 0..n {
-            let a_L_i = Scalar::from_u64((self.v >> i) & 1);
+            let a_L_i = Scalar::from_u64((v >> i) & 1);
             let a_R_i = a_L_i - Scalar::one();
 
             l_poly.0[i] = a_L_i - vc.z;
-            l_poly.1[i] = self.s_L[i];
+            l_poly.1[i] = s_L[i];
             r_poly.0[i] = exp_y * (a_R_i + vc.z) + zz * offset_z * exp_2;
-            r_poly.1[i] = exp_y * self.s_R[i];
+            r_poly.1[i] = exp_y * s_R[i];
 
             exp_y = exp_y * vc.y; // y^i -> y^(i+1)
             exp_2 = exp_2 + exp_2; // 2^i -> 2^(i+1)
@@ -156,73 +201,80 @@ impl<'a> PartyAwaitingValueChallenge<'a> {
         // Generate x by committing to T_1, T_2 (line 49-54)
         let t_1_blinding = Scalar::random(rng);
         let t_2_blinding = Scalar::random(rng);
-        let T_1 = self.generators
-            .share(self.j)
+        let T_1 = generators
+            .share(j)
             .pedersen_generators
             .commit(t_poly.1, t_1_blinding);
-        let T_2 = self.generators
-            .share(self.j)
+        let T_2 = generators
+            .share(j)
             .pedersen_generators
             .commit(t_poly.2, t_2_blinding);
 
         let poly_commitment = PolyCommitment { T_1, T_2 };
 
-        let papc = PartyAwaitingPolyChallenge {
-            value_commitment: self.value_commitment,
+        let papc = PartyState::AwaitingPolyChallenge {
+            value_commitment: value_commitment,
             poly_commitment,
             z: vc.z,
             offset_z,
             l_poly,
             r_poly,
             t_poly,
-            v_blinding: self.v_blinding,
-            a_blinding: self.a_blinding,
-            s_blinding: self.s_blinding,
+            v_blinding: v_blinding,
+            a_blinding: a_blinding,
+            s_blinding: s_blinding,
             t_1_blinding,
             t_2_blinding,
         };
 
-        (papc, poly_commitment)
+        Ok((Party{state:papc}, poly_commitment))
     }
-}
 
-pub struct PartyAwaitingPolyChallenge {
-    value_commitment: ValueCommitment,
-    poly_commitment: PolyCommitment,
-    z: Scalar,
-    offset_z: Scalar,
-    l_poly: util::VecPoly1,
-    r_poly: util::VecPoly1,
-    t_poly: util::Poly2,
-    v_blinding: Scalar,
-    a_blinding: Scalar,
-    s_blinding: Scalar,
-    t_1_blinding: Scalar,
-    t_2_blinding: Scalar,
-}
-
-impl PartyAwaitingPolyChallenge {
-    pub fn apply_challenge(self, pc: &PolyChallenge) -> Result<ProofShare, &'static str> {
+    pub fn apply_poly_challenge(self, pc: &PolyChallenge) -> Result<ProofShare, &'static str> {
         // Prevent a malicious dealer from annihilating the blinding factors:
         if pc.x == Scalar::zero() {
             return Err("Poly challenge was zero, which would leak secrets, bailing out");
         }
+        let (value_commitment, poly_commitment, z,
+             offset_z, l_poly, r_poly, t_poly,
+             v_blinding, a_blinding, s_blinding,
+             t_1_blinding, t_2_blinding)
+            = match self.state {
+                PartyState::AwaitingPolyChallenge {
+                    value_commitment,
+                    poly_commitment,
+                    z,
+                    offset_z,
+                    l_poly,
+                    r_poly,
+                    t_poly,
+                    v_blinding,
+                    a_blinding,
+                    s_blinding,
+                    t_1_blinding,
+                    t_2_blinding,
+                } => (value_commitment, poly_commitment, z,
+                      offset_z, l_poly, r_poly, t_poly,
+                      v_blinding, a_blinding, s_blinding,
+                      t_1_blinding, t_2_blinding),
+                _ => return Err("invalid state")
+        };
 
         let t_blinding_poly = util::Poly2(
-            self.z * self.z * self.offset_z * self.v_blinding,
-            self.t_1_blinding,
-            self.t_2_blinding,
+            z * z * offset_z * v_blinding,
+            t_1_blinding,
+            t_2_blinding,
         );
 
-        let t_x = self.t_poly.eval(pc.x);
+        let t_x = t_poly.eval(pc.x);
         let t_x_blinding = t_blinding_poly.eval(pc.x);
-        let e_blinding = self.a_blinding + self.s_blinding * &pc.x;
-        let l_vec = self.l_poly.eval(pc.x);
-        let r_vec = self.r_poly.eval(pc.x);
+        let e_blinding = a_blinding + s_blinding * &pc.x;
+        let l_vec = l_poly.eval(pc.x);
+        let r_vec = r_poly.eval(pc.x);
 
         Ok(ProofShare {
-            value_commitment: self.value_commitment,
-            poly_commitment: self.poly_commitment,
+            value_commitment: value_commitment,
+            poly_commitment: poly_commitment,
             t_x_blinding,
             t_x,
             e_blinding,


### PR DESCRIPTION
Warning: annoying bike-shedding proposal incoming... 😄 

While looking around, the 'Party and Dealer state machines' design caught my attention. It's a very effective way of using the language, and it could be even better in the following way:

1. 'more idiomatic' Rust. This is subjective so I won't spend a lot of words on it, let's just say that it feels to me that using an `enum` of `struct` is more idiomatic than having a separate `struct` for each state(while retaining all previous benefits). 
2. A more secure, and flexible, implementation. 

Re 2, while the 'move semantics' of the type system prevents use after move, you are also implicitly relying on `Clone` never being implemented for the various state structs. `Clone` could end-up being derived or implemented in the future, either by accident, carelessness, or outright trickery. You won't get a warning from the compiler if that happens.

Also, while Rust's "orphan rules" prevent a third-party from implementing `Clone` outside of your crate, the rule aims at "trait coherence", not "trait security", it's very complicated, and it might change or have some exceptions in the future(here is a [general overview](http://smallcultfollowing.com/babysteps/blog/2015/01/14/little-orphan-impls/)).

While this rule can probably be relied on for it's core aim of preventing multiple conflicting implementations, it's maybe not best to rely on it to prevent potential malicious parties to implement a trait for one of your types for which the trait has been left unimplemented. 

Hence, you could consider to adopt a more future-proof solution of preemptively implementing `Clone` yourself, ensuring any clone could never be useful for a replay attack, and having the compiler prevent any conflicting implementation. 

Incidentally, this is easily done using the proposed design, highlighting it's flexibility.

I look forward to your thoughts, and would be happy to continue with `Dealer` if you feel it is worthwhile. 