### PR TITLE
Clarify the `generators` API.

### DIFF
--- a/benches/bulletproofs.rs
+++ b/benches/bulletproofs.rs
@@ -87,7 +87,7 @@ fn verify_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
             ).unwrap();
 
             // XXX would be nice to have some convenience API for this
-            let pg = &generators.all().pedersen_generators;
+            let pg = &generators.pedersen_generators;
             let value_commitments: Vec<_> = values
                 .iter()
                 .zip(blindings.iter())
@@ -100,7 +100,7 @@ fn verify_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
 
                 proof.verify(
                     &value_commitments,
-                    generators.all(),
+                    &generators,
                     &mut transcript,
                     &mut rng,
                     n,

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -1,8 +1,8 @@
-//! The `dealer` module contains the API for the dealer state while the dealer is 
-//! engaging in an aggregated multiparty computation protocol. 
+//! The `dealer` module contains the API for the dealer state while the dealer is
+//! engaging in an aggregated multiparty computation protocol.
 //!
 //! For more explanation of how the `dealer`, `party`, and `messages` modules orchestrate the protocol execution, see
-//! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol). 
+//! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol).
 
 use rand::Rng;
 
@@ -10,7 +10,7 @@ use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::Identity;
 
-use generators::GeneratorsView;
+use generators::Generators;
 use inner_product_proof;
 use proof_transcript::ProofTranscript;
 use range_proof::RangeProof;
@@ -25,7 +25,7 @@ pub struct Dealer {}
 impl Dealer {
     /// Creates a new dealer coordinating `m` parties proving `n`-bit ranges.
     pub fn new<'a, 'b>(
-        gens: GeneratorsView<'b>,
+        gens: &'b Generators,
         n: usize,
         m: usize,
         transcript: &'a mut ProofTranscript,
@@ -74,7 +74,7 @@ pub struct DealerAwaitingValueCommitments<'a, 'b> {
     /// The dealer keeps a copy of the initial transcript state, so
     /// that it can attempt to verify the aggregated proof at the end.
     initial_transcript: ProofTranscript,
-    gens: GeneratorsView<'b>,
+    gens: &'b Generators,
 }
 
 impl<'a, 'b> DealerAwaitingValueCommitments<'a, 'b> {
@@ -125,7 +125,7 @@ pub struct DealerAwaitingPolyCommitments<'a, 'b> {
     m: usize,
     transcript: &'a mut ProofTranscript,
     initial_transcript: ProofTranscript,
-    gens: GeneratorsView<'b>,
+    gens: &'b Generators,
     value_challenge: ValueChallenge,
 }
 
@@ -171,7 +171,7 @@ pub struct DealerAwaitingProofShares<'a, 'b> {
     m: usize,
     transcript: &'a mut ProofTranscript,
     initial_transcript: ProofTranscript,
-    gens: GeneratorsView<'b>,
+    gens: &'b Generators,
     value_challenge: ValueChallenge,
     poly_challenge: PolyChallenge,
 }

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -1,8 +1,8 @@
 //! The `messages` module contains the API for the messages passed between the parties and the dealer
-//! in an aggregated multiparty computation protocol. 
-//! 
+//! in an aggregated multiparty computation protocol.
+//!
 //! For more explanation of how the `dealer`, `party`, and `messages` modules orchestrate the protocol execution, see
-//! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol). 
+//! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol).
 
 use std::iter;
 

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -1,8 +1,8 @@
-//! The `party` module contains the API for the party state while the party is 
-//! engaging in an aggregated multiparty computation protocol. 
+//! The `party` module contains the API for the party state while the party is
+//! engaging in an aggregated multiparty computation protocol.
 //!
 //! For more explanation of how the `dealer`, `party`, and `messages` modules orchestrate the protocol execution, see
-//! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol). 
+//! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol).
 
 use curve25519_dalek::ristretto;
 use curve25519_dalek::ristretto::RistrettoPoint;


### PR DESCRIPTION
The `GeneratorsView` struct was originally intended to be a view into the
"full" (m,n) generators for a specific proof share.  But the
`Generators::all()` method gave a `GeneratorsView` that covered all of the
generators. This meant that `GeneratorsView` ended up having a duplicate role
to `&Generators`, and that it wasn't possible to tell whether a
`GeneratorsView` was for a specific share or was being used like a
`&Generators`.

This commit drops the `Generators::all()` method in order to fix this
inconsistency.