### PR TITLE
Streamline messages in aggregation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["cryptography", "ristretto", "zero-knowledge", "bulletproofs"]
 description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 
 [dependencies]
-curve25519-dalek = { version = "^0.16", features = ["serde", "nightly"] }
+curve25519-dalek = { version = "=0.16.4", features = ["serde", "nightly"] }
 subtle = "0.6"
 sha2 = "^0.7"
 rand = "^0.4"

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -93,14 +93,14 @@ impl RangeProof {
             .map(|(j, p)| p.assign_position(j, rng))
             .unzip();
 
-        let (dealer, value_challenge) = dealer.receive_value_commitments(&value_commitments)?;
+        let (dealer, value_challenge) = dealer.receive_value_commitments(value_commitments)?;
 
         let (parties, poly_commitments): (Vec<_>, Vec<_>) = parties
             .into_iter()
             .map(|p| p.apply_challenge(&value_challenge, rng))
             .unzip();
 
-        let (dealer, poly_challenge) = dealer.receive_poly_commitments(&poly_commitments)?;
+        let (dealer, poly_challenge) = dealer.receive_poly_commitments(poly_commitments)?;
 
         let proof_shares: Vec<_> = parties
             .into_iter()
@@ -434,7 +434,7 @@ mod tests {
         let (party3, value_com3) = party3.assign_position(3, &mut rng);
 
         let (dealer, value_challenge) = dealer
-            .receive_value_commitments(&[value_com0, value_com1, value_com2, value_com3])
+            .receive_value_commitments(vec![value_com0, value_com1, value_com2, value_com3])
             .unwrap();
 
         let (party0, poly_com0) = party0.apply_challenge(&value_challenge, &mut rng);
@@ -443,7 +443,7 @@ mod tests {
         let (party3, poly_com3) = party3.apply_challenge(&value_challenge, &mut rng);
 
         let (dealer, poly_challenge) = dealer
-            .receive_poly_commitments(&[poly_com0, poly_com1, poly_com2, poly_com3])
+            .receive_poly_commitments(vec![poly_com0, poly_com1, poly_com2, poly_com3])
             .unwrap();
 
         let share0 = party0.apply_challenge(&poly_challenge).unwrap();
@@ -486,11 +486,12 @@ mod tests {
 
         let (party0, value_com0) = party0.assign_position(0, &mut rng);
 
-        let (dealer, value_challenge) = dealer.receive_value_commitments(&[value_com0]).unwrap();
+        let (dealer, value_challenge) = dealer.receive_value_commitments(vec![value_com0]).unwrap();
 
         let (party0, poly_com0) = party0.apply_challenge(&value_challenge, &mut rng);
 
-        let (_dealer, mut poly_challenge) = dealer.receive_poly_commitments(&[poly_com0]).unwrap();
+        let (_dealer, mut poly_challenge) =
+            dealer.receive_poly_commitments(vec![poly_com0]).unwrap();
 
         // But now simulate a malicious dealer choosing x = 0
         poly_challenge.x = Scalar::zero();

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -88,14 +88,17 @@ impl<'a> PartyAwaitingPosition<'a> {
         );
 
         // Return next state and all commitments
-        let value_commitment = ValueCommitment { V: self.V, A, S };
+        let value_commitment = ValueCommitment {
+            V_j: self.V,
+            A_j: A,
+            S_j: S,
+        };
         let next_state = PartyAwaitingValueChallenge {
             n: self.n,
             v: self.v,
             v_blinding: self.v_blinding,
             generators: self.generators,
             j,
-            value_commitment,
             a_blinding,
             s_blinding,
             s_L,
@@ -114,7 +117,6 @@ pub struct PartyAwaitingValueChallenge<'a> {
 
     j: usize,
     generators: &'a Generators,
-    value_commitment: ValueCommitment,
     a_blinding: Scalar,
     s_blinding: Scalar,
     s_L: Vec<Scalar>,
@@ -165,11 +167,12 @@ impl<'a> PartyAwaitingValueChallenge<'a> {
             .pedersen_generators
             .commit(t_poly.2, t_2_blinding);
 
-        let poly_commitment = PolyCommitment { T_1, T_2 };
+        let poly_commitment = PolyCommitment {
+            T_1_j: T_1,
+            T_2_j: T_2,
+        };
 
         let papc = PartyAwaitingPolyChallenge {
-            value_commitment: self.value_commitment,
-            poly_commitment,
             z: vc.z,
             offset_z,
             l_poly,
@@ -187,8 +190,6 @@ impl<'a> PartyAwaitingValueChallenge<'a> {
 }
 
 pub struct PartyAwaitingPolyChallenge {
-    value_commitment: ValueCommitment,
-    poly_commitment: PolyCommitment,
     z: Scalar,
     offset_z: Scalar,
     l_poly: util::VecPoly1,
@@ -221,8 +222,6 @@ impl PartyAwaitingPolyChallenge {
         let r_vec = self.r_poly.eval(pc.x);
 
         Ok(ProofShare {
-            value_commitment: self.value_commitment,
-            poly_commitment: self.poly_commitment,
             t_x_blinding,
             t_x,
             e_blinding,

--- a/src/util.rs
+++ b/src/util.rs
@@ -124,7 +124,7 @@ pub fn sum_of_powers(x: &Scalar, n: usize) -> Scalar {
 
 // takes the sum of all of the powers of x, up to n
 fn sum_of_powers_slow(x: &Scalar, n: usize) -> Scalar {
-    exp_iter(*x).take(n).fold(Scalar::zero(), |acc, x| acc + x)
+    exp_iter(*x).take(n).sum()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Ensure that no data is sent to the dealer twice (so it cannot be different)
- Pass the dealer's data into the proof share auditing
- Make auditing slightly more efficient
- Use `Sum` convenience functions

Co-authored-by: Cathie Yun <cathieyun@gmail.com>