### PR TITLE
Update to `curve25519-dalek` 0.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ rust:
 
 env:
   - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES=''
-  - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='yolocrypto'
+  - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='avx2_backend'
   # run cargo bench with a filter that matches no benchmarks.
   # this ensures the benchmarks build but doesn't run them on the CI server.
-  - TEST_COMMAND=bench EXTRA_FLAGS='"DONTRUNBENCHMARKS"' FEATURES='yolocrypto'
+  - TEST_COMMAND=bench EXTRA_FLAGS='"DONTRUNBENCHMARKS"' FEATURES='avx2_backend'
 
 script:
   - cargo $TEST_COMMAND --features="$FEATURES" $EXTRA_FLAGS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["cryptography", "ristretto", "zero-knowledge", "bulletproofs"]
 description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 
 [dependencies]
-curve25519-dalek = { version = "=0.16.4", features = ["serde", "nightly"] }
+curve25519-dalek = { version = "0.17", features = ["serde"] }
 subtle = "0.6"
 sha2 = "^0.7"
-rand = "^0.4"
+rand = "0.5.0-pre.2"
 byteorder = "1.2.1"
 serde = "1"
 serde_derive = "1"
@@ -27,7 +27,7 @@ criterion = "0.2"
 bincode = "1"
 
 [features]
-yolocrypto = ["curve25519-dalek/yolocrypto"]
+avx2_backend = ["curve25519-dalek/avx2_backend", "curve25519-dalek/yolocrypto"]
 
 [[bench]]
 name = "bulletproofs"

--- a/benches/bulletproofs.rs
+++ b/benches/bulletproofs.rs
@@ -4,7 +4,7 @@ extern crate criterion;
 use criterion::Criterion;
 
 extern crate rand;
-use rand::{OsRng, Rng};
+use rand::{rngs::OsRng, Rng};
 
 extern crate curve25519_dalek;
 use curve25519_dalek::scalar::Scalar;

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -5,11 +5,11 @@
 #![deny(missing_docs)]
 
 // XXX we should use Sha3 everywhere
+use sha2::{Digest, Sha512};
 
-use curve25519_dalek::ristretto;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
-use sha2::{Digest, Sha512};
+use curve25519_dalek::traits::MultiscalarMul;
 
 /// The `GeneratorsChain` creates an arbitrary-long sequence of orthogonal generators.
 /// The sequence can be deterministically produced starting with an arbitrary point.
@@ -90,7 +90,7 @@ pub struct PedersenGenerators {
 impl PedersenGenerators {
     /// Creates a Pedersen commitment using the value scalar and a blinding factor.
     pub fn commit(&self, value: Scalar, blinding: Scalar) -> RistrettoPoint {
-        ristretto::multiscalar_mul(&[value, blinding], &[self.B, self.B_blinding])
+        RistrettoPoint::multiscalar_mul(&[value, blinding], &[self.B, self.B_blinding])
     }
 }
 

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -5,9 +5,9 @@
 use std::borrow::Borrow;
 use std::iter;
 
-use curve25519_dalek::ristretto;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::traits::VartimeMultiscalarMul;
 
 use proof_transcript::ProofTranscript;
 
@@ -77,12 +77,12 @@ impl InnerProductProof {
             let c_L = inner_product(&a_L, &b_R);
             let c_R = inner_product(&a_R, &b_L);
 
-            let L = ristretto::vartime::multiscalar_mul(
+            let L = RistrettoPoint::vartime_multiscalar_mul(
                 a_L.iter().chain(b_R.iter()).chain(iter::once(&c_L)),
                 G_R.iter().chain(H_L.iter()).chain(iter::once(Q)),
             );
 
-            let R = ristretto::vartime::multiscalar_mul(
+            let R = RistrettoPoint::vartime_multiscalar_mul(
                 a_R.iter().chain(b_L.iter()).chain(iter::once(&c_R)),
                 G_L.iter().chain(H_R.iter()).chain(iter::once(Q)),
             );
@@ -99,8 +99,8 @@ impl InnerProductProof {
             for i in 0..n {
                 a_L[i] = a_L[i] * u + u_inv * a_R[i];
                 b_L[i] = b_L[i] * u_inv + u * b_R[i];
-                G_L[i] = ristretto::vartime::multiscalar_mul(&[u_inv, u], &[G_L[i], G_R[i]]);
-                H_L[i] = ristretto::vartime::multiscalar_mul(&[u, u_inv], &[H_L[i], H_R[i]]);
+                G_L[i] = RistrettoPoint::vartime_multiscalar_mul(&[u_inv, u], &[G_L[i], G_R[i]]);
+                H_L[i] = RistrettoPoint::vartime_multiscalar_mul(&[u, u_inv], &[H_L[i], H_R[i]]);
             }
 
             a = a_L;
@@ -201,7 +201,7 @@ impl InnerProductProof {
         let neg_u_sq = u_sq.iter().map(|ui| -ui);
         let neg_u_inv_sq = u_inv_sq.iter().map(|ui| -ui);
 
-        let expect_P = ristretto::vartime::multiscalar_mul(
+        let expect_P = RistrettoPoint::vartime_multiscalar_mul(
             iter::once(self.a * self.b)
                 .chain(a_times_s)
                 .chain(h_times_b_div_s)
@@ -274,7 +274,7 @@ mod tests {
         // a.iter() has Item=&Scalar, need Item=Scalar to chain with b_prime
         let a_prime = a.iter().cloned();
 
-        let P = ristretto::vartime::multiscalar_mul(
+        let P = RistrettoPoint::vartime_multiscalar_mul(
             a_prime.chain(b_prime).chain(iter::once(c)),
             G.iter().chain(H.iter()).chain(iter::once(&Q)),
         );

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -4,7 +4,7 @@
 //! For more explanation of how the `dealer`, `party`, and `messages` modules orchestrate the protocol execution, see
 //! [the API for the aggregated multiparty computation protocol](../aggregation/index.html#api-for-the-aggregated-multiparty-computation-protocol).
 
-use rand::Rng;
+use rand::{CryptoRng, Rng};
 
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
@@ -251,7 +251,7 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
     /// error.
     ///
     /// XXX define error types so we can surface the blame info
-    pub fn receive_shares<R: Rng>(
+    pub fn receive_shares<R: Rng + CryptoRng>(
         mut self,
         rng: &mut R,
         proof_shares: &[ProofShare],

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -58,8 +58,7 @@ impl ProofShare {
     ) -> Result<(), &'static str> {
         use std::iter;
 
-        use curve25519_dalek::ristretto;
-        use curve25519_dalek::traits::IsIdentity;
+        use curve25519_dalek::traits::{IsIdentity, VartimeMultiscalarMul};
 
         use inner_product_proof::inner_product;
         use util;
@@ -89,7 +88,7 @@ impl ProofShare {
                 z + exp_y_inv * y_jn_inv * (-r_i) + exp_y_inv * y_jn_inv * (zz * z_j * exp_2)
             });
 
-        let P_check = ristretto::vartime::multiscalar_mul(
+        let P_check = RistrettoPoint::vartime_multiscalar_mul(
             iter::once(Scalar::one())
                 .chain(iter::once(*x))
                 .chain(iter::once(-self.e_blinding))
@@ -108,7 +107,7 @@ impl ProofShare {
         let sum_of_powers_y = util::sum_of_powers(&y, n);
         let sum_of_powers_2 = util::sum_of_powers(&Scalar::from_u64(2), n);
         let delta = (z - zz) * sum_of_powers_y * y_jn - z * zz * sum_of_powers_2 * z_j;
-        let t_check = ristretto::vartime::multiscalar_mul(
+        let t_check = RistrettoPoint::vartime_multiscalar_mul(
             iter::once(zz * z_j)
                 .chain(iter::once(*x))
                 .chain(iter::once(x * x))


### PR DESCRIPTION
The main changes are:

1. `rand` moves to `0.5.0-pre.2` from `0.4`
2. Multiscalar multiplication uses traits now.

The first change allows us to use `OsRng` on `wasm32-unknown-unknown`
targets (which is implemented by FFI to the browser crypto APIs).

The second change allows us to drop in @oleganza's Pippenger branch with
a `[replace]` directive for testing large problem sizes.