### PR TITLE
Serde optional and `Clear_on_drop` replaced by `Zeroize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Entries are listed in reverse chronological order.
 
+## 2.0.1
+
+* `Serde` is optional.
+* Adds new backends for `curve25519-dalek`: `u32_backend`, `u64_backend`, 
+  and `avx2_backend`(default on `std`).
+* Replace `clear_on_drop` by `zeroize`.
+
 ## 2.0.0
 
 * Switch from `failure` to `std`-compatible errors via `thiserror`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "bulletproofs"
 # - update html_root_url
 # - ensure yoloproofs was disabled in an atomic (revertable) commit
 # - update CHANGELOG
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Cathie Yun <cathieyun@gmail.com>", 
            "Henry de Valence <hdevalence@hdevalence.ca>",
            "Oleg Andreev <oleganza@gmail.com>"]
@@ -18,18 +18,18 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 edition = "2018"
 
 [dependencies]
-curve25519-dalek = { version = "2", default-features = false, features = ["u64_backend", "nightly", "serde", "alloc"] }
+curve25519-dalek = { version = "2", default-features = false, features = [ "alloc", "nightly"] }
 subtle = { version = "2", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 digest = { version = "0.8", default-features = false }
 rand_core = { version = "0.5", default-features = false, features = ["alloc"] }
-rand = { version = "0.7", default-features = false, optional = true }
+rand = { version = "0.7", default-features = false }
 byteorder = { version = "1", default-features = false }
-serde = { version = "1", default-features = false, features = ["alloc"] }
-serde_derive = { version = "1", default-features = false }
+serde = { version = "1", default-features = false, features = ["alloc"], optional = true }
+serde_derive = { version = "1", default-features = false, optional = true }
 thiserror = { version = "1", optional = true }
 merlin = { version = "2", default-features = false }
-clear_on_drop = { version = "0.2", default-features = false, features = ["nightly"] }
+zeroize = { version = "1.1.0", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
 hex = "0.3"
@@ -38,10 +38,20 @@ bincode = "1"
 rand_chacha = "0.2"
 
 [features]
-default = ["std", "avx2_backend"]
+default = ["std", "avx2_backend", "zeroize"]
+
+u64_backend = ["curve25519-dalek/u64_backend", ]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
+u32_backend = ["curve25519-dalek/u32_backend"] 
 # yoloproofs = []
-std = ["rand", "rand/std", "thiserror"]
+
+std = [
+	"serde",
+	"serde_derive",
+	"curve25519-dalek/serde",
+	"rand/std", 
+	"thiserror", 
+]
 
 [[test]]
 name = "range_proof"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 extern crate alloc;
 
+#[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde_derive;
 

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -1,12 +1,12 @@
 #![allow(non_snake_case)]
 
-#[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
 use core::mem;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::{Identity, MultiscalarMul};
 use merlin::Transcript;
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 use super::{
     ConstraintSystem, LinearCombination, R1CSProof, RandomizableConstraintSystem,

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -14,7 +14,8 @@ use curve25519_dalek::scalar::Scalar;
 use crate::generators::{BulletproofGens, PedersenGens};
 
 /// A commitment to the bits of a party's value.
-#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BitCommitment {
     pub(super) V_j: CompressedRistretto,
     pub(super) A_j: RistrettoPoint,
@@ -22,28 +23,32 @@ pub struct BitCommitment {
 }
 
 /// Challenge values derived from all parties' [`BitCommitment`]s.
-#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BitChallenge {
     pub(super) y: Scalar,
     pub(super) z: Scalar,
 }
 
 /// A commitment to a party's polynomial coefficents.
-#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PolyCommitment {
     pub(super) T_1_j: RistrettoPoint,
     pub(super) T_2_j: RistrettoPoint,
 }
 
 /// Challenge values derived from all parties' [`PolyCommitment`]s.
-#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PolyChallenge {
     pub(super) x: Scalar,
 }
 
 /// A party's proof share, ready for aggregation into the final
 /// [`RangeProof`](::RangeProof).
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ProofShare {
     pub(super) t_x: Scalar,
     pub(super) t_x_blinding: Scalar,

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -25,7 +25,7 @@ use crate::util;
 use rand_core::{CryptoRng, RngCore};
 
 #[cfg(feature = "serde")]
-use serde::{self, Deserialize, Deserializer, Serialize, Serializer, de::Visitor};
+use serde::{self, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 // Modules for MPC protocol
 

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -23,8 +23,9 @@ use crate::transcript::TranscriptProtocol;
 use crate::util;
 
 use rand_core::{CryptoRng, RngCore};
-use serde::de::Visitor;
-use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+
+#[cfg(feature = "serde")]
+use serde::{self, Deserialize, Deserializer, Serialize, Serializer, de::Visitor};
 
 // Modules for MPC protocol
 
@@ -538,6 +539,7 @@ impl RangeProof {
     }
 }
 
+#[cfg(feature = "serde")]
 impl Serialize for RangeProof {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -547,6 +549,7 @@ impl Serialize for RangeProof {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for RangeProof {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -13,13 +13,13 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-#[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::MultiscalarMul;
 use rand_core::{CryptoRng, RngCore};
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 use crate::errors::MPCError;
 use crate::generators::{BulletproofGens, PedersenGens};

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -13,7 +13,8 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use clear_on_drop::clear::Clear;
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
@@ -145,10 +146,11 @@ impl<'a> PartyAwaitingPosition<'a> {
 }
 
 /// Overwrite secrets with null bytes when they go out of scope.
+#[cfg(feature = "zeroize")]
 impl<'a> Drop for PartyAwaitingPosition<'a> {
     fn drop(&mut self) {
-        self.v.clear();
-        self.v_blinding.clear();
+        self.v.zeroize();
+        self.v_blinding.zeroize();
     }
 }
 
@@ -238,24 +240,16 @@ impl<'a> PartyAwaitingBitChallenge<'a> {
 }
 
 /// Overwrite secrets with null bytes when they go out of scope.
+#[cfg(feature = "zeroize")]
 impl<'a> Drop for PartyAwaitingBitChallenge<'a> {
     fn drop(&mut self) {
-        self.v.clear();
-        self.v_blinding.clear();
-        self.a_blinding.clear();
-        self.s_blinding.clear();
+        self.v.zeroize();
+        self.v_blinding.zeroize();
+        self.a_blinding.zeroize();
+        self.s_blinding.zeroize();
 
-        // Important: due to how ClearOnDrop auto-implements InitializableFromZeroed
-        // for T: Default, calling .clear() on Vec compiles, but does not
-        // clear the content. Instead, it only clears the Vec's header.
-        // Clearing the underlying buffer item-by-item will do the job, but will
-        // keep the header as-is, which is fine since the header does not contain secrets.
-        for e in self.s_L.iter_mut() {
-            e.clear();
-        }
-        for e in self.s_R.iter_mut() {
-            e.clear();
-        }
+        self.s_L.zeroize();
+        self.s_R.zeroize();
     }
 }
 
@@ -306,13 +300,14 @@ impl PartyAwaitingPolyChallenge {
 }
 
 /// Overwrite secrets with null bytes when they go out of scope.
+#[cfg(feature = "zeroize")]
 impl Drop for PartyAwaitingPolyChallenge {
     fn drop(&mut self) {
-        self.v_blinding.clear();
-        self.a_blinding.clear();
-        self.s_blinding.clear();
-        self.t_1_blinding.clear();
-        self.t_2_blinding.clear();
+        self.v_blinding.zeroize();
+        self.a_blinding.zeroize();
+        self.s_blinding.zeroize();
+        self.t_1_blinding.zeroize();
+        self.t_2_blinding.zeroize();
 
         // Note: polynomials r_poly, l_poly and t_poly
         // are cleared within their own Drop impls.

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,9 +5,9 @@ extern crate alloc;
 
 use alloc::vec;
 use alloc::vec::Vec;
+use curve25519_dalek::scalar::Scalar;
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
-use curve25519_dalek::scalar::Scalar;
 
 use crate::inner_product_proof::inner_product;
 


### PR DESCRIPTION
In order to improve the support of  `no_std` and another platforms like WASM:  
* `Serde` is optional
* Replace `clear_on_drop` by `zeroize`:  No inline LLVM asm and WASM support..
* Support different back-ends: `u32_backend`, `u64_backend`, and `avx2_backend`(default in `std`)