### PR TITLE
Add public vector to the transcript in linear proof

### DIFF
--- a/benches/linear_proof.rs
+++ b/benches/linear_proof.rs
@@ -64,7 +64,7 @@ fn create_linear_proof_helper(c: &mut Criterion) {
                     G.clone(),
                     &F,
                     &B,
-                );
+                ).unwrap();
             })
         },
         TEST_SIZES,
@@ -141,7 +141,7 @@ fn linear_verify(c: &mut Criterion) {
                     G.clone(),
                     &F,
                     &B,
-                );
+                ).unwrap();
 
                 (proof, C)
             };
@@ -150,7 +150,7 @@ fn linear_verify(c: &mut Criterion) {
             bench.iter(|| {
                 let mut verifier_transcript = Transcript::new(b"LinearProofBenchmark");
                 proof
-                    .verify(*n, &mut verifier_transcript, &C, &G, &F, &B, b.clone())
+                    .verify(&mut verifier_transcript, &C, &G, &F, &B, b.clone())
                     .unwrap();
             });
         },

--- a/benches/linear_proof.rs
+++ b/benches/linear_proof.rs
@@ -64,7 +64,8 @@ fn create_linear_proof_helper(c: &mut Criterion) {
                     G.clone(),
                     &F,
                     &B,
-                ).unwrap();
+                )
+                .unwrap();
             })
         },
         TEST_SIZES,
@@ -141,7 +142,8 @@ fn linear_verify(c: &mut Criterion) {
                     G.clone(),
                     &F,
                     &B,
-                ).unwrap();
+                )
+                .unwrap();
 
                 (proof, C)
             };

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,6 +37,12 @@ pub enum ProofError {
         error("Invalid generators size, too few generators for proof")
     )]
     InvalidGeneratorsLength,
+    /// This error occurs when inputs are the incorrect length for the proof.
+    #[cfg_attr(
+        feature = "std",
+        error("Invalid input size, incorrect input length for proof")
+    )]
+    InvalidInputLength,
     /// This error results from an internal error during proving.
     ///
     /// The single-party prover is implemented by performing

--- a/src/linear_proof.rs
+++ b/src/linear_proof.rs
@@ -74,6 +74,9 @@ impl LinearProof {
 
         transcript.innerproduct_domain_sep(n as u64);
         transcript.append_point(b"C", &C);
+        for i in 0..n {
+            transcript.append_scalar(b"b_i", &b[i]);
+        }
 
         let lg_n = n.next_power_of_two().trailing_zeros() as usize;
         let mut L_vec = Vec::with_capacity(lg_n);
@@ -165,7 +168,12 @@ impl LinearProof {
         b_vec: Vec<Scalar>,
     ) -> Result<(), ProofError> {
         transcript.innerproduct_domain_sep(n as u64);
+        assert_eq!(b_vec.len(), n);
+
         transcript.append_point(b"C", &C);
+        for i in 0..n {
+            transcript.append_scalar(b"b_i", &b_vec[i]);
+        }
         let (x_vec, x_inv_vec, b_0) = self.verification_scalars(n, transcript, b_vec)?;
 
         transcript.append_point(b"S", &self.S);


### PR DESCRIPTION
Add public vector `b` to the transcript in the linear proof code, to prevent the [frozen heart vulnerability](https://blog.trailofbits.com/2022/04/15/the-frozen-heart-vulnerability-in-bulletproofs/), as advised by Quang Dao. 